### PR TITLE
Bug: LT-1468 - Deactivate users

### DIFF
--- a/core/services.py
+++ b/core/services.py
@@ -1,6 +1,6 @@
 from lite_forms.components import Option
 
-from conf.client import get, post
+from conf.client import get, post, put
 from conf.constants import UNITS_URL, DRAFTS_URL, COUNTRIES_URL, EXTERNAL_LOCATIONS_URL, NOTIFICATIONS_URL, \
     CLC_NOTIFICATIONS_URL, ORGANISATIONS_URL
 
@@ -102,4 +102,14 @@ def get_organisation(request, pk):
 
 def get_organisation_users(request, pk):
     data = get(request, ORGANISATIONS_URL + pk + '/users/')
+    return data.json(), data.status_code
+
+
+def get_organisation_user(request, pk, user_pk):
+    data = get(request, ORGANISATIONS_URL + pk + '/users/' + user_pk)
+    return data.json()
+
+
+def put_organisation_user(request, pk, user_pk, json):
+    data = put(request, ORGANISATIONS_URL + pk + '/users/' + user_pk, json)
     return data.json(), data.status_code

--- a/templates/users/change_status.html
+++ b/templates/users/change_status.html
@@ -7,9 +7,9 @@
 		<div class="buttons-row">
 			{% csrf_token %}
 			{% if status == 'reactivate' %}
-				<button type="submit" name="status" value="Active" class="govuk-button">Reactivate User</button>
+				<button type="submit" name="status" value="Active" class="govuk-button" id="reactivate-confirm">Reactivate User</button>
 			{% else %}
-				<button type="submit" name="status" value="Deactivated" class="govuk-button govuk-button--warning">Deactivate User</button>
+				<button type="submit" name="status" value="Deactivated" class="govuk-button govuk-button--warning" id="deactivate-confirm">Deactivate User</button>
 			{% endif %}
 			<a href="{% url 'users:users' %}" role="button" draggable="false" class="govuk-button govuk-button--secondary">Cancel</a>
 		</div>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -44,9 +44,9 @@
 
 		{% if request.user.lite_api_user_id|stringformat:"s" != user.id|stringformat:"s" %}
 			{% if user.status == 'Active' %}
-				<a href="{% url 'users:change_status' user.id 'deactivate' %}" role="button" draggable="false" class="govuk-button govuk-button--warning govuk-!-margin-right-2">Deactivate</a>
+				<a href="{% url 'users:change_status' user.id 'deactivate' %}" role="button" draggable="false" class="govuk-button govuk-button--warning govuk-!-margin-right-2" id="btn-deactivate">Deactivate</a>
 			{% elif user.status == 'Deactivated' %}
-				<a href="{% url 'users:change_status' user.id 'reactivate' %}" role="button" draggable="false" class="govuk-button govuk-!-margin-right-2">Reactivate</a>
+				<a href="{% url 'users:change_status' user.id 'reactivate' %}" role="button" draggable="false" class="govuk-button govuk-!-margin-right-2" id="btn-reactivate">Reactivate</a>
 			{% endif %}
 		{% endif %}
 	</div>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -18,7 +18,7 @@
 				First Name
 			</dt>
 			<dd class="govuk-summary-list__value">
-				{{ data.user.first_name }}
+				{{ user.first_name }}
 			</dd>
 		</div>
 		<div class="govuk-summary-list__row">
@@ -26,7 +26,7 @@
 				Last Name
 			</dt>
 			<dd class="govuk-summary-list__value">
-				{{ data.user.last_name }}
+				{{ user.last_name }}
 			</dd>
 		</div>
 		<div class="govuk-summary-list__row">
@@ -34,19 +34,19 @@
 				Email
 			</dt>
 			<dd class="govuk-summary-list__value">
-				{{ data.user.email }}
+				{{ user.email }}
 			</dd>
 		</div>
 	</dl>
 
 	<div class="lite-user-profile-container">
-		<a href="{% url 'users:edit' data.user.id %}" type="submit" class="govuk-button govuk-button--secondary">Edit</a>
+		<a href="{% url 'users:edit' user.id %}" type="submit" class="govuk-button govuk-button--secondary">Edit</a>
 
-		{% if request.user.lite_api_user_id|stringformat:"s" != data.user.id|stringformat:"s" %}
-			{% if data.user.status == 'Active' %}
-				<a href="{% url 'users:change_status' data.user.id 'deactivate' %}" role="button" draggable="false" class="govuk-button govuk-button--warning govuk-!-margin-right-2">Deactivate</a>
-			{% elif data.user.status == 'Deactivated' %}
-				<a href="{% url 'users:change_status' data.user.id 'reactivate' %}" role="button" draggable="false" class="govuk-button govuk-!-margin-right-2">Reactivate</a>
+		{% if request.user.lite_api_user_id|stringformat:"s" != user.id|stringformat:"s" %}
+			{% if user.status == 'Active' %}
+				<a href="{% url 'users:change_status' user.id 'deactivate' %}" role="button" draggable="false" class="govuk-button govuk-button--warning govuk-!-margin-right-2">Deactivate</a>
+			{% elif user.status == 'Deactivated' %}
+				<a href="{% url 'users:change_status' user.id 'reactivate' %}" role="button" draggable="false" class="govuk-button govuk-!-margin-right-2">Reactivate</a>
 			{% endif %}
 		{% endif %}
 	</div>

--- a/ui_automation_tests/features/users.feature
+++ b/ui_automation_tests/features/users.feature
@@ -11,10 +11,12 @@ Feature: I want to manage users
     Then I add a user
 
   @add_user
-  Scenario: Add user
+  Scenario: Add user deactivate user reactivate user
     Given I go to exporter homepage and choose Test Org
     When I add user
     Then user is added
+    When I deactivate user then user is deactivated
+    And I reactivate user then user is reactivated
 
   @cant_add_self
   Scenario: Cant add own user
@@ -26,14 +28,6 @@ Feature: I want to manage users
   Scenario: Edit user
     Given I go to exporter homepage and choose Test Org
     When I edit user then user is edited
-
-#  @deactivate
-#  Scenario: Deactivate user
-#    Given I go to exporter homepage and choose Test Org
-#    When I add the second test user
-#    And I deactivate user then user is deactivated
-#    And I go to exporter homepage
-#    And I reactivate user then user is reactivated
 
   @reactivate_oneself
   Scenario: Reactivate oneself

--- a/ui_automation_tests/pages/exporter_hub_page.py
+++ b/ui_automation_tests/pages/exporter_hub_page.py
@@ -81,19 +81,15 @@ class ExporterHubPage:
         self.driver.find_element_by_id("last_name").send_keys(last_name)
 
     def click_user_name_link(self, user_name):
-        element = self.driver.find_element_by_xpath("//*[text()[contains(.,'" + user_name + "')]]")
-        actions = ActionChains(self.driver)
-        actions.move_to_element(element).perform()
-        time.sleep(1)
-        element.click()
+        self.driver.find_element_by_link_text(user_name).click()
 
     def click_deactivate_btn(self):
-        self.driver.find_element_by_xpath("//*[text()[contains(.,'Deactivate')]]").click()
-        self.driver.find_element_by_xpath("//*[text()[contains(.,'Deactivate User')]]").click()
+        self.driver.find_element_by_id("btn-deactivate").click()
+        self.driver.find_element_by_id("deactivate-confirm").click()
 
     def click_reactivate_btn(self):
-        self.driver.find_element_by_xpath("//*[text()[contains(.,'Reactivate')]]").click()
-        self.driver.find_element_by_xpath("//*[text()[contains(.,'Reactivate User')]]").click()
+        self.driver.find_element_by_id("btn-reactivate").click()
+        self.driver.find_element_by_id("reactivate-confirm").click()
 
     def logout(self):
         self.driver.get("https://great.uat.uktrade.io/sso/accounts/")

--- a/users/views.py
+++ b/users/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
 from django.views.generic import TemplateView
 
-from core.services import get_organisation_users, get_organisation
+from core.services import get_organisation_users, get_organisation, get_organisation_user, put_organisation_user
 from users import forms
 from users.services import post_users, update_user, get_user
 
@@ -46,11 +46,10 @@ class AddUser(TemplateView):
 
 class ViewUser(TemplateView):
     def get(self, request, **kwargs):
-        data, status_code = get_user(request, str(kwargs['pk']))
-        user = data.get('user')
+        user = get_organisation_user(request, str(request.user.organisation), str(kwargs['pk']))['user']
 
         context = {
-            'data': data,
+            'user': user,
             'title': user.get('first_name') + ' ' + user.get('last_name')
         }
         return render(request, 'users/profile.html', context)
@@ -116,6 +115,6 @@ class ChangeUserStatus(TemplateView):
         if status != 'deactivate' and status != 'reactivate':
             raise Http404
 
-        update_user(request, str(kwargs['pk']), json={'status': request.POST['status']})
+        put_organisation_user(request, str(request.user.organisation), str(kwargs['pk']), request.POST)
 
         return redirect('/users/')


### PR DESCRIPTION
On Users on exporter, can no longer deactivate them as the button is no longer there

Steps:
Go to exporter homepage
Click manage my organisation
Click Users
Click on a user other than yourself
Notice there is no deactivate button

Changes
Deactivate/Activate works again

How?
Added a couple of endpoints (get and put) to organisations/pk/users/pk which returns all the correct data, and allows us to put data to it