### PR TITLE
test: Move the end user steps in HMRC

### DIFF
--- a/ui_automation_tests/features/hmrc.feature
+++ b/ui_automation_tests/features/hmrc.feature
@@ -9,6 +9,10 @@ Feature: I want to be able to perform actions as a HMRC user
     When I switch organisations to my second organisation
     And I select to raise a query for my first organisation
     And I click continue
+    And I click on hmrc set end user
+    And I add an end user of sub_type: "government", name: "Mr Smith", website: "https://www.smith.com", address: "London" and country "Ukraine"
+    And I upload a file "file_for_doc_upload_test_1.txt"
+    And I click the back link
     And I click on hmrc describe your goods
     When I add a good or good type with description "M4" controlled "Yes" control code "ML1a" incorporated "No" and part number "not needed"
     And I click on link with id "attach_doc"
@@ -18,10 +22,6 @@ Feature: I want to be able to perform actions as a HMRC user
     And I select "organisation" for where my goods are located
     And I select the site at position "1"
     And I click continue
-    And I click the back link
-    And I click on hmrc set end user
-    And I add an end user of sub_type: "government", name: "Mr Smith", website: "https://www.smith.com", address: "London" and country "Ukraine"
-    And I upload a file "file_for_doc_upload_test_1.txt"
     And I click the back link
     And I click on hmrc explain your reasoning
     And I leave a note for the "reasoning"


### PR DESCRIPTION
The HMRC test which adds an end user and document was at the end which meant that by the time it got to the end of the test, the document hadn't been processed yet. I've just moved the end user to earlier so that it has more time to process the document