### PR TITLE
fix: Remove string not found on users page

### DIFF
--- a/templates/users/users.html
+++ b/templates/users/users.html
@@ -42,7 +42,7 @@
 							{{ user.first_name }} {{ user.last_name }}
 						{% else %}
 							<strong class="govuk-tag govuk-phase-banner__content__tag ">
-								{% lcs "USER_PENDING" %}
+								{% lcs "users.UsersPage.USER_PENDING" %}
 							</strong>
 						{% endif %}
 					</td>


### PR DESCRIPTION
Bad
![Screenshot 2020-01-07 at 13 20 46](https://user-images.githubusercontent.com/16895840/71898174-8bc04600-3150-11ea-9abc-d9bf3d031f08.png)

Good
![Screenshot 2020-01-07 at 13 21 13](https://user-images.githubusercontent.com/16895840/71898210-9b3f8f00-3150-11ea-83bc-ac588cbc20f2.png)
