### PR TITLE
fix: LT-2198 - Licence type in draft application not displaying

### DIFF
--- a/templates/applications/drafts.html
+++ b/templates/applications/drafts.html
@@ -63,7 +63,7 @@
 							</a>
 						</td>
 						<td class="govuk-table__cell">
-							{{ draft.application.case_type.sub_type.value }}
+							{{ draft.case_type.sub_type.value }}
 						</td>
 						<td class="govuk-table__cell govuk-table__cell--nowrap">
 							{{ draft.updated_at|str_date }}


### PR DESCRIPTION
- Licence type in the draft application list on exporter was shown as empty due to dictionary keys mismatch
https://uktrade.atlassian.net/browse/LT-2198
