### PR TITLE
test: Less slack spam

### DIFF
--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -98,12 +98,13 @@ spec:
       script {
        //unarchive mapping: ['ui_automation_tests/allure-results/**.*': '.']
        generateAllureReport()
-       // Send Slack notification
-       sendSlackNotification()
       }
     }
+    changed {
+       // Send Slack notification
+       sendSlackNotification()
+    }
   }
-
 }
 
 // Generate Allure report function
@@ -152,7 +153,7 @@ def sendSlackNotification()
 		}
 
 		// Set slack channel
-		channel = "lite-development-team"
+		channel = "lite-merging"
 
 		// Send notifications
 		slackSend (color: colourCode, message: message, channel: "#${channel}")

--- a/ui_automation_tests/step_defs/test_menu.py
+++ b/ui_automation_tests/step_defs/test_menu.py
@@ -6,7 +6,7 @@ scenarios("../features/menu.feature", strict_gherkin=False)
 @then("the log out link is displayed")
 def log_out_link_displayed(driver):
     assert driver.find_element_by_id(
-        "link-sign-out"
+        "link-sign-sout"
     ).is_displayed(), "Log out button is not displayed. User may have the service unavailable screen."
 
 

--- a/ui_automation_tests/step_defs/test_menu.py
+++ b/ui_automation_tests/step_defs/test_menu.py
@@ -6,7 +6,7 @@ scenarios("../features/menu.feature", strict_gherkin=False)
 @then("the log out link is displayed")
 def log_out_link_displayed(driver):
     assert driver.find_element_by_id(
-        "link-sign-sout"
+        "link-sign-out"
     ).is_displayed(), "Log out button is not displayed. User may have the service unavailable screen."
 
 


### PR DESCRIPTION
* Change the Slack Notifications to go to lite-merging channel
* Change the Slack Notifications to only send when there has been a change in result for a build for example previous build was a success, next build is a success - don't notify, if previous build was a success, next build is a failure - notify.