### PR TITLE
bug: removing unwanted navbar from start.html

### DIFF
--- a/templates/core/start.html
+++ b/templates/core/start.html
@@ -2,6 +2,8 @@
 
 {% load svg %}
 
+{% block navigation %}{% endblock %}
+
 {% block header_title %}{% endblock %}
 
 {% block service_name %}{% endblock %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52039706/79204766-f7dbd580-7e34-11ea-88bb-bc9844cbb6ec.png)

- navbar with 'Account home' shouldn't be visible on this page