### PR TITLE
bug: Remove unused get users endpoint

### DIFF
--- a/organisation/members/services.py
+++ b/organisation/members/services.py
@@ -10,11 +10,6 @@ def get_user(request, pk=None):
     return data.json()
 
 
-def get_users(request):
-    data = get(request, USERS_URL)
-    return data.json(), data.status_code
-
-
 def post_users(request, json):
     data = post(request, USERS_URL, json)
     return data.json(), data.status_code


### PR DESCRIPTION
This bug was raised as a performance ticket but it turns out the endpoint isn't even used so I'm removing it