### PR TITLE
fix: Tile notifications

### DIFF
--- a/assets/css/components/_tiles.scss
+++ b/assets/css/components/_tiles.scss
@@ -15,13 +15,17 @@
 
 .app-tile {
 	@include govuk-responsive-padding(5);
+	@include govuk-responsive-padding(2, "bottom");
 	background-color: govuk-colour("light-grey");
 	border-top: govuk-spacing(1) solid $govuk-brand-colour;
 	box-sizing: border-box;
-	@include govuk-responsive-padding(2, "bottom");
 
 	& > * {
 		margin-bottom: govuk-spacing(3)!important;
+
+		@include govuk-media-query($until: tablet) {
+			margin-bottom: govuk-spacing(1)!important;
+		}
 	}
 
 	.lite-notification-bubble {

--- a/assets/css/components/_tiles.scss
+++ b/assets/css/components/_tiles.scss
@@ -30,6 +30,10 @@
 		text-decoration: none !important;
 		display: inline-block;
 		margin-left: govuk-spacing(1);
+		min-width: 22px;
+		width: auto;
+		box-sizing: border-box;
+		padding: 0 govuk-spacing(1);
 	}
 
 	.app-tile__heading {
@@ -38,6 +42,13 @@
 		@include govuk-font($size: 19, $weight: bold);
 		display: inline-block;
 		text-decoration: underline;
+
+		p {
+			display: inline-block;
+			margin: 0;
+			padding: 0;
+			text-decoration: inherit;
+		}
 	}
 
 	.app-tile__body {

--- a/assets/css/components/_tiles.scss
+++ b/assets/css/components/_tiles.scss
@@ -18,7 +18,7 @@
 	background-color: govuk-colour("light-grey");
 	border-top: govuk-spacing(1) solid $govuk-brand-colour;
 	box-sizing: border-box;
-	padding-bottom: 0!important;
+	@include govuk-responsive-padding(2, "bottom");
 
 	& > * {
 		margin-bottom: govuk-spacing(3)!important;

--- a/assets/css/components/_tiles.scss
+++ b/assets/css/components/_tiles.scss
@@ -46,7 +46,6 @@
 		p {
 			display: inline-block;
 			margin: 0;
-			padding: 0;
 			text-decoration: inherit;
 		}
 	}

--- a/templates/core/hub.html
+++ b/templates/core/hub.html
@@ -52,12 +52,7 @@
 			{% if existing.applications %}
 				<div class="app-tile">
 					<a href="{% url 'applications:applications' %}" class="app-tile__heading" id="link-applications">
-						{% lcs 'hub.Tiles.APPLICATIONS' %}
-						{% if notifications.notifications.application %}
-							<span id="applications-notifications" class="lite-notification-bubble">
-								<span class="govuk-visually-hidden">(</span>{{ notifications.notifications.application }} <span class="govuk-visually-hidden">notifications)</span>
-							</span>
-						{% endif %}
+						<p>{% lcs 'hub.Tiles.APPLICATIONS' %}</p>{% if notifications.notifications.application %}<span id="applications-notifications" class="lite-notification-bubble"><span class="govuk-visually-hidden"> (</span>{{ notifications.notifications.application }} <span class="govuk-visually-hidden">notifications)</span></span>{% endif %}
 					</a>
 					<p class="app-tile__body">{% lcs 'hub.Tiles.Applications.CHECK_PROGRESS' %}</p>
 					<p class="app-tile__body">{% lcs 'hub.Tiles.Applications.EDIT_APPLICATIONS' %}</p>
@@ -78,10 +73,8 @@
 			{# Product list tile #}
 			<div class="app-tile">
 				<a href="{% url 'goods:goods' %}" class="app-tile__heading" id="link-products">
-					{% lcs 'hub.Tiles.GOODS' %}{% if notifications.notifications.goods %}<span class="lite-notification-bubble" id="product-notifications">{{ notifications.notifications.goods }}</span>
-				{% endif %}
+					{% lcs 'hub.Tiles.GOODS' %}{% if notifications.notifications.goods %}<span class="lite-notification-bubble" id="product-notifications">{{ notifications.notifications.goods }}</span>{% endif %}
 				</a>
-
 				<p class="app-tile__body">{% lcs 'hub.Tiles.ProductList.MANAGE_PRODUCTS' %}</p>
 				<p class="app-tile__body">{% lcs 'hub.Tiles.ProductList.PRODUCTS_INCLUDE' %}</p>
 				<ol class="govuk-list govuk-!-font-size-16">
@@ -101,10 +94,8 @@
 			{# End user query tile #}
 			<div class="app-tile">
 				<a href="{% url 'end_users:end_users' %}" class="app-tile__heading" id="link-eua">
-					{% lcs 'hub.Tiles.END_USER_ADVISORIES' %}{% if notifications.notifications.end_user_advisory %}<span class="lite-notification-bubble" id="eua-notifications">{{ notifications.notifications.end_user_advisory }}</span>
-				{% endif %}
+					{% lcs 'hub.Tiles.END_USER_ADVISORIES' %}{% if notifications.notifications.end_user_advisory %}<span class="lite-notification-bubble" id="eua-notifications">{{ notifications.notifications.end_user_advisory }}</span>{% endif %}
 				</a>
-
 				<p class="app-tile__body">{% lcs 'hub.Tiles.EUA.ASK_FOR_ADVICE' %}</p>
 			</div>
 		</section>

--- a/templates/core/hub.html
+++ b/templates/core/hub.html
@@ -31,7 +31,6 @@
 	</div>
 
 	{% if organisation.type.key != 'hmrc' %}
-		{# First section #}
 		<section class="app-tiles">
 			{# Apply tile #}
 			<div class="app-tile">
@@ -68,7 +67,6 @@
 			</div>
 		</section>
 
-		{# Second section #}
 		<section class="app-tiles">
 			{# Product list tile #}
 			<div class="app-tile">

--- a/templates/core/hub.html
+++ b/templates/core/hub.html
@@ -1,7 +1,7 @@
 {% extends 'layouts/base.html' %}
 
 {% block title %}
-	{% lcs 'hub.TITLE' %}
+	{% lcs 'hub.ACCOUNT_HOME' %}
 {% endblock %}
 
 {% block header_title %}<span></span>{% endblock %}

--- a/templates/core/hub.html
+++ b/templates/core/hub.html
@@ -73,7 +73,7 @@
 			{# Product list tile #}
 			<div class="app-tile">
 				<a href="{% url 'goods:goods' %}" class="app-tile__heading" id="link-products">
-					{% lcs 'hub.Tiles.GOODS' %}{% if notifications.notifications.goods %}<span class="lite-notification-bubble" id="product-notifications">{{ notifications.notifications.goods }}</span>{% endif %}
+					{% lcs 'hub.Tiles.GOODS' %}{% if notifications.notifications.goods %}<span class="lite-notification-bubble" id="product-notifications"><span class="govuk-visually-hidden"> (</span>{{ notifications.notifications.goods }}</span><span class="govuk-visually-hidden"> notifications)</span>{% endif %}
 				</a>
 				<p class="app-tile__body">{% lcs 'hub.Tiles.ProductList.MANAGE_PRODUCTS' %}</p>
 				<p class="app-tile__body">{% lcs 'hub.Tiles.ProductList.PRODUCTS_INCLUDE' %}</p>
@@ -94,7 +94,7 @@
 			{# End user query tile #}
 			<div class="app-tile">
 				<a href="{% url 'end_users:end_users' %}" class="app-tile__heading" id="link-eua">
-					{% lcs 'hub.Tiles.END_USER_ADVISORIES' %}{% if notifications.notifications.end_user_advisory %}<span class="lite-notification-bubble" id="eua-notifications">{{ notifications.notifications.end_user_advisory }}</span>{% endif %}
+					{% lcs 'hub.Tiles.END_USER_ADVISORIES' %}{% if notifications.notifications.end_user_advisory %}<span class="lite-notification-bubble" id="eua-notifications"><span class="govuk-visually-hidden"> (</span>{{ notifications.notifications.end_user_advisory }}<span class="govuk-visually-hidden"> notifications)</span></span>{% endif %}
 				</a>
 				<p class="app-tile__body">{% lcs 'hub.Tiles.EUA.ASK_FOR_ADVICE' %}</p>
 			</div>
@@ -107,7 +107,7 @@
 					{% lcs 'hub.Tiles.CustomsEnquiry.MAKE_ENQUIRY' %}
 				</a>
 				<p class="app-tile__body">
-					<a href="{% url "applications:applications" %}?submitted=False" class="govuk-link govuk-link--no-visited-state">
+					<a href="{% url 'applications:applications' %}?submitted=False" class="govuk-link govuk-link--no-visited-state">
 						{% lcs 'hub.Tiles.CustomsEnquiry.DRAFT_LINK' %}
 					</a>
 				</p>


### PR DESCRIPTION
<img width="409" alt="image" src="https://user-images.githubusercontent.com/43062514/85402454-a0a06280-b553-11ea-9995-d31552135e3e.png">

* Fixes the link underline being too wide
* Notifications above 99 now show correctly (no more overflow)
* Fixed padding on tiles on mobile
* More accessibility improvements 